### PR TITLE
Remove the blank space above the notebook action buttons when in iframe mode

### DIFF
--- a/zeppelin-web/src/assets/styles/looknfeel/default.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/default.css
@@ -22,6 +22,10 @@ body {
   border-bottom: 1px solid #E5E5E5;
 }
 
+body.bodyAsIframe .noteAction {
+  top: 0px;
+}
+
 .editor,
 .executionTime,
 .nv-controlsWrap {


### PR DESCRIPTION
This is the companion PR to https://github.com/SkymindIO/lagom-skil-api/pull/1222 which styles the zeppelin notebook iframes so they look more integrated with our UI.

When in 'iframe mode' we scootch the toolbar up to the top of the iframe.

The before and after images can be seen in the [other PR](https://github.com/SkymindIO/lagom-skil-api/pull/1222).