### PR TITLE
support token login

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+/*
+    To redefine some job/run parameters,
+    please provide arguments to jenkinsBuilder step.
+    Example: jenkinsBuilder platforms: []
+ */
+
+jenkinsBuilder()
+

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
 
-    <skil.version>1.2.0</skil.version>
+    <skil.version>1.2.1-SNAPSHOT</skil.version>
     <java.jwt.version>3.2.0</java.jwt.version>
   </properties>
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -221,11 +221,7 @@ public class LoginRestApi {
             throw new AuthenticationException(errMsg);
           }
 
-          if (userName == null || password == null || password.equalsIgnoreCase("null")) {
-            return login(splitAuthHeader[1]);
-          } else {
-            this.addSource(LoginSource.SKIL_API);
-          }
+          this.addSource(LoginSource.SKIL_API);
         }
 
         UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
@@ -271,8 +267,6 @@ public class LoginRestApi {
       } catch (AuthenticationException ae) {
         //unexpected condition - error?
         LOG.error("Exception in login: ", ae);
-      } catch (IOException e) {
-        e.printStackTrace();
       }
     }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -21,6 +21,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.skymind.auth.model.User;
+import io.skymind.auth.shiro.SkilToken;
 import io.skymind.skil.daemon.client.SKILDaemonClient;
 import io.skymind.skil.daemon.service.ServiceInfo;
 import org.apache.shiro.authc.*;
@@ -148,20 +149,27 @@ public class LoginRestApi {
       gsonBuilder.setExclusionStrategies(new JsonExclusionStrategy());
       Gson gson = gsonBuilder.create();
       User user = gson.fromJson(subject, User.class);
-      UsernamePasswordToken token = new UsernamePasswordToken(
-              user.getUserName(),
-              user.getPassword()
-      );
+
+      SkilToken token = new SkilToken(token1);
 
       Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
       currentUser.getSession().stop();
       currentUser.getSession(true);
       currentUser.login(token);
-      String principal = SecurityUtils.getPrincipal();
 
       HashSet<String> roles = new HashSet<>();
-      roles.add(user.getRole().toString());
-      String ticket = TicketContainer.instance.getTicket(principal);
+      if (LoginRestApi.currentUser != null) {
+        roles.add(LoginRestApi.currentUser.getRole().toString());
+      } else {
+        roles = SecurityUtils.getRoles();
+      }
+      String principal = SecurityUtils.getPrincipal();
+      String ticket;
+      if ("anonymous".equals(principal))
+        ticket = "anonymous";
+      else
+        ticket = TicketContainer.instance.getTicket(principal);
+
       Map<String, String> data = new HashMap<>();
       data.put("principal", principal);
       data.put("roles", roles.toString());
@@ -173,6 +181,7 @@ public class LoginRestApi {
       response = new JsonResponse(Response.Status.FORBIDDEN, "", "");
     }
 
+    LOG.warn(response.toString());
     return response.build();
   }
 
@@ -197,6 +206,28 @@ public class LoginRestApi {
     }
     if (!currentUser.isAuthenticated()) {
       try {
+        // check post login request come from Zeppelin login form or SKIL apis
+        if (authHeader == null || authHeader.isEmpty()) {
+          this.addSource(LoginSource.LOGIN_FORM);
+        } else {
+          // check if the auth header is valid or not
+          String[] splitAuthHeader = authHeader.split(" ");
+          String errMsg = null;
+          if (splitAuthHeader.length != 2) {
+            errMsg = "NOT a valid authorization header for SKIL apis access";
+            throw new AuthenticationException(errMsg);
+          } else if (!isValidSkilToken(splitAuthHeader[1])) {
+            errMsg = "NOT a valid JWT token in the authorization header for SKIL apis access";
+            throw new AuthenticationException(errMsg);
+          }
+
+          if (userName == null || password == null || password.equalsIgnoreCase("null")) {
+            return login(splitAuthHeader[1]);
+          } else {
+            this.addSource(LoginSource.SKIL_API);
+          }
+        }
+
         UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
         //      token.setRememberMe(true);
 
@@ -228,24 +259,6 @@ public class LoginRestApi {
         //set roles for user in NotebookAuthorization module
         NotebookAuthorization.getInstance().setRoles(principal, roles);
 
-        // check post login request come from Zeppelin login form or SKIL apis
-        if (authHeader == null || authHeader.isEmpty()) {
-          this.addSource(LoginSource.LOGIN_FORM);
-        } else {
-          // check if the auth header is valid or not
-          String[] splitAuthHeader = authHeader.split(" ");
-          String errMsg = null;
-          if (splitAuthHeader.length != 2) {
-            errMsg = "NOT a valid authorization header for SKIL apis access";
-            throw new AuthenticationException(errMsg);
-          } else if (!isValidSkilToken(splitAuthHeader[1])){
-            errMsg = "NOT a valid JWT token in the authorization header for SKIL apis access";
-            throw new AuthenticationException(errMsg);
-          }
-
-          this.addSource(LoginSource.SKIL_API);
-        }
-
       } catch (UnknownAccountException uae) {
         //username wasn't in the system, show them an error message?
         LOG.error("Exception in login: ", uae);
@@ -258,6 +271,8 @@ public class LoginRestApi {
       } catch (AuthenticationException ae) {
         //unexpected condition - error?
         LOG.error("Exception in login: ", ae);
+      } catch (IOException e) {
+        e.printStackTrace();
       }
     }
 


### PR DESCRIPTION
since we removed user password from skil token's payload
we need to change the current login function.

as-was: SKIL tries to login to zeppelin via id and pw for RPC
as-is: SKIL tries to login to zeppelin via skil token 